### PR TITLE
Bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 pbr
 Sphinx
-asyncio==3.4.3
 APScheduler==3.0.5
-redis==2.10.3
-pyzmq==15.1.0
+redis==2.10.5
+pyzmq==15.2.0
 kafka-python==0.9.5
-requests==2.8.1
+requests==2.9.1
 aiomeasures==0.5.14


### PR DESCRIPTION
Drop asyncio dependency as we require Python 3.4 anyway.